### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,7 @@ permissions: {}
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read # Required for actions/checkout to clone the private repo.
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,9 +12,9 @@ permissions: {}
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     permissions:
-      contents: read # Required for actions/checkout to clone the private repo.
+      contents: read # Required to checkout the private repo.
 
     steps:
     - name: Checkout code

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,10 +5,16 @@ on:
     types: [published]
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    
+    permissions:
+      contents: read # Required for actions/checkout to clone the private repo.
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: read # Required to checkout the private repo.
+      contents: read # Required to checkout the repo.
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/newfold-labs/image-processing-service/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 1 (`deploy.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | `366686a` |
| Timeouts commit | `58b2d71` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `deploy.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| deploy.yml | 1 job was missing a scoped `permissions:` directive | deploy | `contents: read` [3] |


## Permissions corrections (previously incorrect)

No pre-existing configured `permissions:` were identified as incorrect.

## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| deploy.yml | deploy | `30` | SSH-based deploy that pulls the repo, rebuilds Docker images, waits on container startup, and runs health checks; 30 minutes provides ample headroom for slow image builds while still preventing a hung SSH session from burning Actions minutes. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | The `appleboy/ssh-action@v0.1.8` step performs all GitHub-side work over SSH using the `DROPLET_*` secrets (no `GITHUB_TOKEN` is forwarded), so it requires no GitHub API permissions. The only token-using step is `actions/checkout@v3`, which needs `contents: read` against this private repo — already added. |
| 2 | `actions/checkout@v3` and `appleboy/ssh-action@v0.1.8` are pinned to outdated/floating tags. Out of scope for this audit but worth a follow-up to pin to current major versions (or commit SHAs) for supply-chain hygiene. |


